### PR TITLE
Prevent tube to appear twice in labels when map config applied

### DIFF
--- a/mapper.go
+++ b/mapper.go
@@ -127,7 +127,6 @@ func (m *tubeMapper) initFromString(fileContents string) error {
 
 	// get the list of unique labels across all mappings
 	delete(allLabels, "name")
-	allLabels["tube"] = 1
 	labelNames := make([]string, len(allLabels))
 	i := 0
 	for k := range allLabels {


### PR DESCRIPTION
a fix for a case when the process run with mapconfig crashes with panic: Inconsistent label cardinality

the case related to https://github.com/messagebird/beanstalkd_exporter/issues/10



