### PR TITLE
allow user to exclude stats for each tube in metrics

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -38,9 +38,11 @@ type Exporter struct {
 
 	// use to collects all the errors asynchronously
 	cherrs chan error
+
+	ExportTubeStats bool
 }
 
-func NewExporter(address string) *Exporter {
+func NewExporter(address string, exportTubeStats bool) *Exporter {
 	cherrs := make(chan error)
 	exporter := &Exporter{
 		address: address,
@@ -71,6 +73,8 @@ func NewExporter(address string) *Exporter {
 		),
 
 		cherrs: cherrs,
+
+		ExportTubeStats: exportTubeStats,
 	}
 
 	go func(e *Exporter) {
@@ -195,6 +199,10 @@ func (e *Exporter) scrape(conn *beanstalk.Conn) []prometheus.Collector {
 
 	if *logLevel == "debug" {
 		log.Debugf("Debug: Calling %s ListTubes()", e.address)
+	}
+
+	if !e.ExportTubeStats {
+		return collectors
 	}
 
 	// stat every tube

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ var (
 	numTubeStatWorkers = flag.Int("num-tube-stat-workers", 1, "The number of concurrent workers to use to fetch tube stats.")
 	listenAddress      = flag.String("web.listen-address", ":8080", "Address to listen on for web interface and telemetry.")
 	metricsPath        = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
+	exportTubeStats    = flag.Bool("export-tube-stats", true, "Include tube stats in metrics.")
 )
 
 var (
@@ -74,7 +75,7 @@ func main() {
 		}
 		go watchConfig(*mappingConfig, mapper)
 	}
-	exporter := NewExporter(*address)
+	exporter := NewExporter(*address, *exportTubeStats)
 	exporter.SetConnectionTimeout(*connectionTimeout)
 	registry = prometheus.NewRegistry()
 	registry.MustRegister(exporter)


### PR DESCRIPTION
The use case required to avoid an export of stats for each tube. It is needed when there is only interest in common stats and number of tubes can significantly increase metrics size. This could happen, for instance, in my production system where we have over 500 tubes per each VMs. 6 VMs in total. By avoiding such an export, i can remove an extra load from prometheus. 