### PR TITLE
Remove unused flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,7 @@ this application via an HTTP request to /metrics. During this scrape
 request the exporter will connect to beanstalk and ask for stats. Stats
 are fetched for the whole instance and for each individual tube.
 
-If you have many tubes and fetching stats one-by-one takes longer than
-your allowed scrape duration configured in prometheus, you can increase
-the number of concurrent tube stats workers via the
-`-num-tube-stat-workers` flag, to parallelize the work required.
+It is gonna create one worker per tube in order to fetch the stats.
 
 ## Usage
 
@@ -41,10 +38,6 @@ Usage of ./bin/beanstalkd_exporter:
     	A file that describes a mapping of tube names.
   -poll int
     	The number of seconds that we poll the beanstalkd server for stats. (default 30)
-  -sleep-between-tube-stats int
-    	The number of milliseconds to sleep between tube stats. (default 5000)
-  -num-tube-stat-workers int
-    	The number of concurrent workers to use to fetch tube stats. (default 1)
   -web.listen-address string
     	Address to listen on for web interface and telemetry. (default ":8080")
   -web.telemetry-path string

--- a/main.go
+++ b/main.go
@@ -15,8 +15,6 @@ var (
 	connectionTimeout  = flag.Duration("beanstalkd.connection-timeout", 0, "Timeout value for tcp connection to Beanstalkd")
 	logLevel           = flag.String("log.level", "warning", "The log level.")
 	mappingConfig      = flag.String("mapping-config", "", "A file that describes a mapping of tube names.")
-	sleepBetweenStats  = flag.Int("sleep-between-tube-stats", 5000, "The number of milliseconds to sleep between tube stats.")
-	numTubeStatWorkers = flag.Int("num-tube-stat-workers", 1, "The number of concurrent workers to use to fetch tube stats.")
 	listenAddress      = flag.String("web.listen-address", ":8080", "Address to listen on for web interface and telemetry.")
 	metricsPath        = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
 )


### PR DESCRIPTION
Seems like the flags `-sleep-between-tube-stats` and `-num-tube-stat-workers` are not used anymore and haven't been removed. We just create one go routine per tube and to not sleep for any time. I have removed them and updated the docs