### PR TITLE
Ignore additional string-type stats fields

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -172,8 +172,8 @@ func (e *Exporter) scrape(conn *beanstalk.Conn) []prometheus.Collector {
 	}
 	e.scrapeCountMetric.WithLabelValues("success").Inc()
 	for key, value := range stats {
-		// ignore these stats
-		if key == "hostname" || key == "id" || key == "pid" {
+		// ignore these stats (string fields that shouldn't be parsed as numbers)
+		if key == "hostname" || key == "id" || key == "pid" || key == "version" || key == "draining" || key == "os" || key == "platform" {
 			continue
 		}
 


### PR DESCRIPTION
- version
- draining
- os
- platform

Otherwise they would fail to parse (as numeric type).